### PR TITLE
Make equatable functions into extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Collections
+
 Native C# library implementing collections.
 
 ### Arrays
+
 ```cs
 using Array<int> array = new(4);
 array[0] = 1;
@@ -15,6 +17,7 @@ foreach (int item in array)
 ```
 
 ### Lists
+
 ```cs
 using List<int> list = new();
 list.Add(1);
@@ -28,6 +31,7 @@ foreach (int item in list)
 ```
 
 ### Dictionaries
+
 ```cs
 using Dictionary<byte, int> dictionary = new();
 dictionary.Add(1, 1337);
@@ -36,5 +40,19 @@ dictionary.Add(3, 42);
 foreach (byte key in dictionary.Keys)
 {
     Console.WriteLine(dictionary[key]);
+}
+```
+
+### Stacks
+
+```cs
+using Stack<int> stack = new();
+stack.Push(1);
+stack.Push(3);
+stack.Push(3);
+
+while (stack.TryPop(out int item))
+{
+    Console.WriteLine(item);
 }
 ```

--- a/source/Array.cs
+++ b/source/Array.cs
@@ -139,40 +139,6 @@ namespace Collections
         }
 
         /// <summary>
-        /// Attempts to find the index of the given <paramref name="value"/>.
-        /// </summary>
-        /// <returns><c>true</c> if found.</returns>
-        public readonly bool TryIndexOf<V>(V value, out uint index) where V : unmanaged, IEquatable<V>
-        {
-            return Implementation.TryIndexOf(this.value, value, out index);
-        }
-
-        /// <summary>
-        /// Retrieves the index of the given <paramref name="value"/>.
-        /// <para>
-        /// May throw <see cref="NullReferenceException"/> if <paramref name="value"/> was not found.
-        /// </para>
-        /// </summary>
-        /// <returns>Index of the <paramref name="value"/>.</returns>
-        public readonly uint IndexOf<V>(V value) where V : unmanaged, IEquatable<V>
-        {
-            if (!TryIndexOf(value, out uint index))
-            {
-                throw new NullReferenceException($"The value {value} was not found in the array");
-            }
-
-            return index;
-        }
-
-        /// <summary>
-        /// Checks if the array contains the given <paramref name="value"/>.
-        /// </summary>
-        public readonly bool Contains<V>(V value) where V : unmanaged, IEquatable<V>
-        {
-            return Implementation.Contains(this.value, value);
-        }
-
-        /// <summary>
         /// Copies the array to the given <paramref name="destination"/>.
         /// </summary>
         /// <returns>Amount of elements copied.</returns>

--- a/source/Array.cs
+++ b/source/Array.cs
@@ -59,14 +59,6 @@ namespace Collections
             value = Implementation.Allocate(span);
         }
 
-        /// <summary>
-        /// Creates a new array containing elements from the given <paramref name="list"/>.
-        /// </summary>
-        public Array(List<T> list)
-        {
-            value = Implementation.Allocate(list.AsSpan());
-        }
-
 #if NET
         /// <summary>
         /// Creates an empty array.

--- a/source/Extensions/ArrayExtensions.cs
+++ b/source/Extensions/ArrayExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Unmanaged;
+
+namespace Collections
+{
+    public static class ArrayExtensions
+    {
+        public static bool Contains<T>(this Array<T> array, T value) where T : unmanaged, IEquatable<T>
+        {
+            return array.AsSpan().Contains(value);
+        }
+
+        public static uint IndexOf<T>(this Array<T> array, T value) where T : unmanaged, IEquatable<T>
+        {
+            return array.AsSpan().IndexOf(value);
+        }
+
+        public static uint LastIndexOf<T>(this Array<T> array, T value) where T : unmanaged, IEquatable<T>
+        {
+            return array.AsSpan().LastIndexOf(value);
+        }
+
+        public static bool TryIndexOf<T>(this Array<T> array, T value, out uint index) where T : unmanaged, IEquatable<T>
+        {
+            return array.AsSpan().TryIndexOf(value, out index);
+        }
+
+        public static bool TryLastIndexOf<T>(this Array<T> array, T value, out uint index) where T : unmanaged, IEquatable<T>
+        {
+            return array.AsSpan().TryLastIndexOf(value, out index);
+        }
+    }
+}

--- a/source/Extensions/ArrayExtensions.cs
+++ b/source/Extensions/ArrayExtensions.cs
@@ -5,26 +5,47 @@ namespace Collections
 {
     public static class ArrayExtensions
     {
+        /// <summary>
+        /// Checks if the array contains <paramref name="value"/>.
+        /// </summary>
         public static bool Contains<T>(this Array<T> array, T value) where T : unmanaged, IEquatable<T>
         {
             return array.AsSpan().Contains(value);
         }
 
+        /// <summary>
+        /// Retrieves the index for the first occurrence of <paramref name="value"/>.
+        /// <para>
+        /// Will be <see cref="uint.MaxValue"/> if not found.
+        /// </para>
+        /// </summary>
         public static uint IndexOf<T>(this Array<T> array, T value) where T : unmanaged, IEquatable<T>
         {
             return array.AsSpan().IndexOf(value);
         }
 
+        /// <summary>
+        /// Retrieves the index for the last occurrence of <paramref name="value"/>.
+        /// <para>
+        /// Will be <see cref="uint.MaxValue"/> if not found.
+        /// </para>
+        /// </summary>
         public static uint LastIndexOf<T>(this Array<T> array, T value) where T : unmanaged, IEquatable<T>
         {
             return array.AsSpan().LastIndexOf(value);
         }
 
+        /// <summary>
+        /// Tries to retrieve the index for the first occurrence of <paramref name="value"/>.
+        /// </summary>
         public static bool TryIndexOf<T>(this Array<T> array, T value, out uint index) where T : unmanaged, IEquatable<T>
         {
             return array.AsSpan().TryIndexOf(value, out index);
         }
 
+        /// <summary>
+        /// Tries to retrieve the index for the last occurrence of <paramref name="value"/>.
+        /// </summary>
         public static bool TryLastIndexOf<T>(this Array<T> array, T value, out uint index) where T : unmanaged, IEquatable<T>
         {
             return array.AsSpan().TryLastIndexOf(value, out index);

--- a/source/Extensions/ListExtensions.cs
+++ b/source/Extensions/ListExtensions.cs
@@ -5,31 +5,56 @@ namespace Collections
 {
     public static class ListExtensions
     {
+        /// <summary>
+        /// Checks if the list contains <paramref name="value"/>.
+        /// </summary>
         public static bool Contains<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
         {
             return list.AsSpan().Contains(value);
         }
 
+        /// <summary>
+        /// Retrieves the index for the first occurrence of <paramref name="value"/>.
+        /// <para>
+        /// Will be <see cref="uint.MaxValue"/> if not found.
+        /// </para>
+        /// </summary>
         public static uint IndexOf<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
         {
             return list.AsSpan().IndexOf(value);
         }
 
+        /// <summary>
+        /// Retrieves the index for the last occurrence of <paramref name="value"/>.
+        /// <para>
+        /// Will be <see cref="uint.MaxValue"/> if not found.
+        /// </para>
+        /// </summary>
         public static uint LastIndexOf<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
         {
             return list.AsSpan().LastIndexOf(value);
         }
 
+        /// <summary>
+        /// Tries to retrieve the index for the first occurrence of <paramref name="value"/>.
+        /// </summary>
         public static bool TryIndexOf<T>(this List<T> list, T value, out uint index) where T : unmanaged, IEquatable<T>
         {
             return list.AsSpan().TryIndexOf(value, out index);
         }
 
+        /// <summary>
+        /// Tries to retrieve the index for the last occurrence of <paramref name="value"/>.
+        /// </summary>
         public static bool TryLastIndexOf<T>(this List<T> list, T value, out uint index) where T : unmanaged, IEquatable<T>
         {
             return list.AsSpan().TryLastIndexOf(value, out index);
         }
 
+        /// <summary>
+        /// Tries to add <paramref name="value"/> to the list if it's not contained.
+        /// </summary>
+        /// <returns><c>true</c> if it was added.</returns>
         public static bool TryAdd<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
         {
             bool contains = list.Contains(value);
@@ -41,6 +66,10 @@ namespace Collections
             return !contains;
         }
 
+        /// <summary>
+        /// Tries to remove <paramref name="value"/> from the list if it's present.
+        /// </summary>
+        /// <returns><c>true</c> if it was removed.</returns>
         public static bool TryRemove<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
         {
             bool contains = list.TryIndexOf(value, out uint index);
@@ -52,6 +81,11 @@ namespace Collections
             return contains;
         }
 
+        /// <summary>
+        /// Tries to remove <paramref name="value"/> from the list,
+        /// by swapping it with the last element if it's present.
+        /// </summary>
+        /// <returns><c>true</c> if it was removed.</returns>
         public static bool TryRemoveBySwapping<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
         {
             bool contains = list.TryIndexOf(value, out uint index);

--- a/source/Extensions/ListExtensions.cs
+++ b/source/Extensions/ListExtensions.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Unmanaged;
+
+namespace Collections
+{
+    public static class ListExtensions
+    {
+        public static bool Contains<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
+        {
+            return list.AsSpan().Contains(value);
+        }
+
+        public static uint IndexOf<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
+        {
+            return list.AsSpan().IndexOf(value);
+        }
+
+        public static uint LastIndexOf<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
+        {
+            return list.AsSpan().LastIndexOf(value);
+        }
+
+        public static bool TryIndexOf<T>(this List<T> list, T value, out uint index) where T : unmanaged, IEquatable<T>
+        {
+            return list.AsSpan().TryIndexOf(value, out index);
+        }
+
+        public static bool TryLastIndexOf<T>(this List<T> list, T value, out uint index) where T : unmanaged, IEquatable<T>
+        {
+            return list.AsSpan().TryLastIndexOf(value, out index);
+        }
+
+        public static bool TryAdd<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
+        {
+            bool contains = list.Contains(value);
+            if (!contains)
+            {
+                list.Add(value);
+            }
+
+            return !contains;
+        }
+
+        public static bool TryRemove<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
+        {
+            bool contains = list.TryIndexOf(value, out uint index);
+            if (contains)
+            {
+                list.RemoveAt(index);
+            }
+
+            return contains;
+        }
+
+        public static bool TryRemoveBySwapping<T>(this List<T> list, T value) where T : unmanaged, IEquatable<T>
+        {
+            bool contains = list.TryIndexOf(value, out uint index);
+            if (contains)
+            {
+                list.RemoveAtBySwapping(index);
+            }
+
+            return contains;
+        }
+    }
+}

--- a/source/Extensions/StackExtensions.cs
+++ b/source/Extensions/StackExtensions.cs
@@ -5,9 +5,27 @@ namespace Collections
 {
     public static class StackExtensions
     {
+        /// <summary>
+        /// Checks if the stack contains <paramref name="value"/>.
+        /// </summary>
         public static bool Contains<T>(this Stack<T> stack, T value) where T : unmanaged, IEquatable<T>
         {
             return stack.AsSpan().Contains(value);
+        }
+
+        /// <summary>
+        /// Tries to push <paramref name="value"/> to the stack if it's not contained.
+        /// </summary>
+        /// <returns><c>true</c> if it was pushed.</returns>
+        public static bool TryPush<T>(this Stack<T> stack, T value) where T : unmanaged, IEquatable<T>
+        {
+            bool contains = stack.Contains(value);
+            if (!contains)
+            {
+                stack.Push(value);
+            }
+
+            return !contains;
         }
     }
 }

--- a/source/Extensions/StackExtensions.cs
+++ b/source/Extensions/StackExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Unmanaged;
+
+namespace Collections
+{
+    public static class StackExtensions
+    {
+        public static bool Contains<T>(this Stack<T> stack, T value) where T : unmanaged, IEquatable<T>
+        {
+            return stack.AsSpan().Contains(value);
+        }
+    }
+}

--- a/source/Implementations/Stack.cs
+++ b/source/Implementations/Stack.cs
@@ -110,22 +110,5 @@ namespace Collections.Implementations
 
             return stack->items.AsSpan<T>(0, stack->top);
         }
-
-        public static bool Contains<T>(Stack* stack, T item) where T : unmanaged
-        {
-            Allocations.ThrowIfNull(stack);
-
-            EqualityComparer<T> comparer = EqualityComparer<T>.Default;
-            for (uint i = 0; i < stack->top; i++)
-            {
-                T element = stack->items.Read<T>(i * stack->stride);
-                if (comparer.Equals(element, item))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
     }
 }

--- a/source/List.cs
+++ b/source/List.cs
@@ -119,14 +119,6 @@ namespace Collections
         }
 
         /// <summary>
-        /// Returns the list as a span of a different type <typeparamref name="V"/>.
-        /// </summary>
-        public readonly USpan<V> AsSpan<V>() where V : unmanaged
-        {
-            return Implementation.AsSpan<V>(value);
-        }
-
-        /// <summary>
         /// Returns the remaining span starting from <paramref name="start"/>.
         /// </summary>
         public readonly USpan<T> AsSpan(uint start)
@@ -160,22 +152,6 @@ namespace Collections
         public readonly void Add(T item)
         {
             Implementation.Add(value, item);
-        }
-
-        /// <summary>
-        /// Attempts to add the given item if its unique.
-        /// </summary>
-        /// <returns><c>true</c> if item was added.</returns>
-        public readonly bool TryAdd<V>(V item) where V : unmanaged, IEquatable<V>
-        {
-            USpan<V> span = Implementation.AsSpan<V>(value);
-            if (span.Contains(item))
-            {
-                return false;
-            }
-
-            Implementation.Add(value, item);
-            return true;
         }
 
         /// <summary>
@@ -223,7 +199,7 @@ namespace Collections
                 throw new IndexOutOfRangeException($"Index {index} is greater than the count {count}");
             }
 
-            uint length = span.Length;
+            //todo: efficiency: this deserves its own logic
             if (index == count)
             {
                 AddRange(span);
@@ -246,15 +222,6 @@ namespace Collections
         }
 
         /// <summary>
-        /// Adds the given <paramref name="span"/> of <typeparamref name="V"/> into
-        /// the list, assuming its size equals to <typeparamref name="T"/>.
-        /// </summary>
-        public readonly void AddRange<V>(USpan<V> span) where V : unmanaged
-        {
-            Implementation.AddRange(value, span);
-        }
-
-        /// <summary>
         /// Adds the given <paramref name="list"/> to the list.
         /// </summary>
         public readonly void AddRange(List<T> list)
@@ -264,54 +231,7 @@ namespace Collections
         }
 
         /// <summary>
-        /// Returns the index of the given <paramref name="item"/> in the list.
-        /// <para>
-        /// May throw <see cref="NullReferenceException"/> if the item is not found.
-        /// </para>
-        /// </summary>
-        /// <exception cref="NullReferenceException"></exception>
-        public readonly uint IndexOf<V>(V item) where V : unmanaged, IEquatable<V>
-        {
-            return Implementation.IndexOf(value, item);
-        }
-
-        /// <summary>
-        /// Attempts to find the index of the given <paramref name="item"/>.
-        /// </summary>
-        /// <returns><c>true</c> if found.</returns>
-        public readonly bool TryIndexOf<V>(V item, out uint index) where V : unmanaged, IEquatable<V>
-        {
-            return Implementation.TryIndexOf(value, item, out index);
-        }
-
-        /// <summary>
-        /// Checks whether the list contains the given <paramref name="item"/>.
-        /// </summary>
-        public readonly bool Contains<V>(V item) where V : unmanaged, IEquatable<V>
-        {
-            return Implementation.Contains(value, item);
-        }
-
-        /// <summary>
-        /// Attempts to remove the given <paramref name="item"/> from the list
-        /// by swapping it with the removed element.
-        /// </summary>
-        /// <returns><c>true</c> if the item was removed.</returns>
-        public readonly bool TryRemoveBySwapping<V>(V item) where V : unmanaged, IEquatable<V>
-        {
-            if (TryIndexOf(item, out uint index))
-            {
-                RemoveAtBySwapping(index);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Removes the element at the given index.
+        /// Removes the element at the given index and returns the removed value.
         /// <para>
         /// May throw <see cref="IndexOutOfRangeException"/> if the index is outside the bounds.
         /// </para>
@@ -326,41 +246,18 @@ namespace Collections
         }
 
         /// <summary>
-        /// Removes the element at the given index by swapping it with the last element.
+        /// Removes the element at the given index by swapping it with the last element,
+        /// and returns the removed value.
         /// <para>
         /// May throw <see cref="IndexOutOfRangeException"/> if the index is outside the bounds.
         /// </para>
         /// </summary>
         /// <exception cref="IndexOutOfRangeException"></exception>"
-        public readonly void RemoveAtBySwapping(uint index)
+        public readonly T RemoveAtBySwapping(uint index)
         {
+            T removed = this[index];
             Implementation.RemoveAtBySwapping(value, index);
-        }
-
-        /// <summary>
-        /// Removes the element at the given index.
-        /// <para>
-        /// May throw <see cref="IndexOutOfRangeException"/> if the index is outside the bounds.
-        /// </para>
-        /// </summary>
-        /// <returns>The removed element.</returns>
-        /// <exception cref="IndexOutOfRangeException"></exception>"
-        public readonly V RemoveAt<V>(uint index) where V : unmanaged, IEquatable<V>
-        {
-            return Implementation.RemoveAt<V>(value, index);
-        }
-
-        /// <summary>
-        /// Removes the element at the given index by swapping it with the last element.
-        /// <para>
-        /// May throw <see cref="IndexOutOfRangeException"/> if the index is outside the bounds.
-        /// </para>
-        /// </summary>
-        /// <returns>The removed element.</returns>
-        /// <exception cref="IndexOutOfRangeException"></exception>"
-        public readonly V RemoveAtBySwapping<V>(uint index) where V : unmanaged, IEquatable<V>
-        {
-            return Implementation.RemoveAtBySwapping<V>(value, index);
+            return removed;
         }
 
         /// <summary>

--- a/source/List.cs
+++ b/source/List.cs
@@ -29,11 +29,6 @@ namespace Collections
         public readonly uint Capacity => Implementation.GetCapacity(value);
 
         /// <summary>
-        /// Native address where the memory for elements begin.
-        /// </summary>
-        public readonly nint StartAddress => Implementation.GetStartAddress(value);
-
-        /// <summary>
         /// Native address of this list.
         /// </summary>
         public readonly nint Address => (nint)value;
@@ -222,12 +217,11 @@ namespace Collections
         }
 
         /// <summary>
-        /// Adds the given <paramref name="list"/> to the list.
+        /// Retrieves the address where items start.
         /// </summary>
-        public readonly void AddRange(List<T> list)
+        public readonly nint GetStartAddress()
         {
-            nint address = Implementation.GetStartAddress(list.value);
-            Implementation.AddRange(value, (void*)address, list.Count);
+            return Implementation.GetStartAddress(value);
         }
 
         /// <summary>

--- a/source/Stack.cs
+++ b/source/Stack.cs
@@ -13,12 +13,23 @@ namespace Collections
     {
         private Implementation* implementation;
 
+        /// <summary>
+        /// Checks if this stack has been disposed.
+        /// </summary>
         public readonly bool IsDisposed => implementation is null;
+
+        /// <summary>
+        /// Amount of items in the stack.
+        /// </summary>
         public readonly uint Count => implementation->top;
+
+        /// <summary>
+        /// Checks if the stack is empty.
+        /// </summary>
         public readonly bool IsEmpty => implementation->top == 0;
 
         int ICollection<T>.Count => (int)implementation->top;
-        bool ICollection<T>.IsReadOnly => false;
+        readonly bool ICollection<T>.IsReadOnly => false;
         int IReadOnlyCollection<T>.Count => (int)implementation->top;
 
 #if NET
@@ -115,17 +126,27 @@ namespace Collections
             }
         }
 
-        public readonly bool Contains(T item)
-        {
-            return Implementation.Contains(implementation, item);
-        }
-
         readonly void ICollection<T>.Add(T item)
         {
             Push(item);
         }
 
-        void ICollection<T>.CopyTo(T[] array, int arrayIndex)
+        readonly bool ICollection<T>.Contains(T item)
+        {
+            EqualityComparer<T> comparer = EqualityComparer<T>.Default;
+            USpan<T> span = AsSpan();
+            for (uint i = 0; i < span.Length; i++)
+            {
+                if (comparer.Equals(span[i], item))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        readonly void ICollection<T>.CopyTo(T[] array, int arrayIndex)
         {
             USpan<T> span = AsSpan();
             for (uint i = 0; i < span.Length; i++)
@@ -134,9 +155,9 @@ namespace Collections
             }
         }
 
-        bool ICollection<T>.Remove(T item)
+        readonly bool ICollection<T>.Remove(T item)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public readonly Enumerator GetEnumerator()


### PR DESCRIPTION
without this change, the surface types end up declaring some functions twice. once for the generic type parameter, and another for a different isolated generic type:
```cs
public readonly bool Contains(T item)
public readonly bool Contains<V>(V item) where V : unmanaged, IEquatable<V>
```

these are now extensions and completely removed from the surface types. for the interfaces that they implement, they have their own slower logic (a non issue since to interact with that youll have to box).